### PR TITLE
fixed race GetNumInProgress

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -89,5 +89,5 @@ func (c *ConcurrencyLimiter) Wait() {
 
 // GetNumInProgress returns a (racy) counter of how many go routines are active right now
 func (c *ConcurrencyLimiter) GetNumInProgress() int32 {
-	return c.numInProgress
+	return atomic.LoadInt32(&c.numInProgress)
 }


### PR DESCRIPTION
Hello! 
Fixed a race condition in `GetNumInProgress` issue #5. 
Can you accept a pull request?

After: 
```
go test --race ./...
ok  	github.com/arteev/limiter

```
Before:
```
WARNING: DATA RACE
Read at 0x00c00014c010 by goroutine 70:
  github.com/arteev/limiter.TestLimit.func1()
      /home/user/go/src/github.com/arteev/limiter/limiter.go:92 +0xc4
  github.com/arteev/limiter.(*ConcurrencyLimiter).Execute.func1()
      /home/user/go/src/github.com/arteev/limiter/limiter.go:56 +0x72

Previous write at 0x00c00014c010 by goroutine 68:
  sync/atomic.AddInt32()
      /usr/local/go1.13.linux-amd64/src/runtime/race_amd64.s:269 +0xb
  github.com/arteev/limiter.(*ConcurrencyLimiter).Execute()
      /home/user/go/src/github.com/arteev/limiter/limiter.go:47 +0x8b
  github.com/arteev/limiter.TestLimit()
      /home/user/go/src/github.com/arteev/limiter/limiter_test.go:33 +0xe1
  testing.tRunner()
      /usr/local/go1.13.linux-amd64/src/testing/testing.go:909 +0x199

Goroutine 70 (running) created at:
  github.com/arteev/limiter.(*ConcurrencyLimiter).Execute()
      /home/user/go/src/github.com/arteev/limiter/limiter.go:48 +0xc1
  github.com/arteev/limiter.TestLimit()
      /home/user/go/src/github.com/arteev/limiter/limiter_test.go:33 +0xe1
  testing.tRunner()
      /usr/local/go1.13.linux-amd64/src/testing/testing.go:909 +0x199

Goroutine 68 (running) created at:
  testing.(*T).Run()
      /usr/local/go1.13.linux-amd64/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/local/go1.13.linux-amd64/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /usr/local/go1.13.linux-amd64/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/local/go1.13.linux-amd64/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /usr/local/go1.13.linux-amd64/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:48 +0x223
==================
--- FAIL: TestLimit (0.01s)
    limiter_test.go:47: results: 100
    limiter_test.go:48: max: 3
    testing.go:853: race detected during execution of test
FAIL
FAIL    github.com/arteev/limiter       0.076s
FAIL
```