### PR TITLE
adding NewConcurrencyLimiterForIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,29 @@ limit the number of concurrent go routines to 10:
   log.Println("httpGoogle:", httpGoogle)
   log.Println("httpApple:", httpApple)
 ```
+
+## Concurrent IO with Error tracking:
+
+```
+  import "github.com/korovkin/limiter"
+  ...
+	a := errors.New("error a")
+	b := errors.New("error b")
+
+	concurrently := limiter.NewConcurrencyLimiterForIO(limiter.DefaultConcurrencyLimitIO)
+	concurrently.Execute(func() {
+		// Do some really slow IO ...
+		// keep the error:
+		concurrently.FirstErrorStore(a)
+	})
+	concurrently.Execute(func() {
+		// Do some really slow IO ...
+		// keep the error:
+		concurrently.FirstErrorStore(b)
+	})
+	concurrently.WaitAndClose()
+
+	firstErr := concurrently.FirstErrorGet()
+	Expect(firstErr == a || firstErr == b).To(BeTrue())
+
+```

--- a/concurrently.go
+++ b/concurrently.go
@@ -1,0 +1,51 @@
+package limiter
+
+import (
+	"sync/atomic"
+)
+
+const (
+	DefaultConcurrencyLimitIO = 4
+)
+
+// Concurrently - execute tasks (IO) concurrently, keep track of the first error atomically
+type Concurrently struct {
+	conc       *ConcurrencyLimiter
+	firstError atomic.Value // type: error
+	// TODO:: we can also add an atomic list of errors here if needed.
+}
+
+func NewConcurrencyLimiterForIO(limit int) *Concurrently {
+	c := &Concurrently{
+		conc:       NewConcurrencyLimiter(limit),
+		firstError: atomic.Value{},
+	}
+	if c.conc == nil {
+		c = nil
+	}
+	return c
+}
+
+func (c *Concurrently) Execute(job func()) (int, error) {
+	return c.conc.Execute(job)
+}
+
+func (c *Concurrently) WaitAndClose() error {
+	return c.conc.WaitAndClose()
+}
+
+func (c *Concurrently) FirstErrorStore(e error) error {
+	if e != nil {
+		c.firstError.Store(e)
+	}
+	return e
+}
+
+func (c *Concurrently) FirstErrorGet() error {
+	e := c.firstError.Load()
+	if e == nil {
+		return nil
+	}
+	err := e.(error)
+	return err
+}


### PR DESCRIPTION
adding NewConcurrencyLimiterForIO with an example and some tests 

good for limited IO works with built in "first error" tracking 
(can be extended to a list of errors, instead of the first error) 

